### PR TITLE
Add minVersion field to mixins.json

### DIFF
--- a/forge/src/main/resources/realismForge.mixins.json
+++ b/forge/src/main/resources/realismForge.mixins.json
@@ -1,5 +1,6 @@
 {
   "required": true,
+  "minVersion": "0.8",
   "package": "net.Realism.forge.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [


### PR DESCRIPTION
Hi !
I tried the mod in 1.20.1 with NeoForge and I got this error :

`[main/ERROR] [mixin/]: Mixin config realismForge.mixins.json does not specify "minVersion" property`

I added the property to the file inside je jar archive and it worked. I therefore propose this patch. Feel free to comment and modify if needed.